### PR TITLE
 feat: cargo.target field

### DIFF
--- a/data/crate.yml
+++ b/data/crate.yml
@@ -1,1 +1,0 @@
-target: x86_64-unknown-linux-gnu

--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,8 @@ pub struct Arguments {
     pub data_dir: Vec<path::PathBuf>,
     #[structopt(long = "manifest-path", name = "PATH", parse(from_os_str))]
     pub manifest_path: Option<path::PathBuf>,
+    #[structopt(long = "target", name = "TRIPLE")]
+    pub target: Option<String>,
     #[structopt(flatten)]
     pub output: Output,
     #[structopt(long = "dump",

--- a/src/de.rs
+++ b/src/de.rs
@@ -75,7 +75,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            target: stager::de::Template::new("{{cargo.name}}-{{cargo.version}}-{{crate.target}}"),
+            target: stager::de::Template::new("{{cargo.name}}-{{cargo.version}}-{{cargo.target}}"),
             stage: Default::default(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,13 +303,13 @@ fn run() -> Result<exitcode::ExitCode, failure::Error> {
 
     let format = args.output.format;
     let target = config.target.format(&engine)?;
-    let output_dir = args.output
-        .dir
-        .as_ref()
-        .ok_or_else(|| failure::Context::new("`--output` is required"))?;
-    let output = output_dir.join(format!("{}{}", target, format.ext()));
-    info!("Writing out {:?} as {:?}", output, format);
+    info!("Writing out {:?} as {:?}", target, format);
     if !args.output.dry_run {
+        let output_dir = args.output
+            .dir
+            .as_ref()
+            .ok_or_else(|| failure::Context::new("`--output` is required"))?;
+        let output = output_dir.join(format!("{}{}", target, format.ext()));
         fs::create_dir_all(&output_dir)?;
         compress::compress(staging_dir.path(), &output, format)?;
     }

--- a/tarball-config.yml
+++ b/tarball-config.yml
@@ -4,5 +4,5 @@ stage:
     path: "{{cargo.target_directory}}/debug/cargo-tarball"
   "/completions":
   - type: SourceFiles
-    path: "{{cargo.target_directory}}/debug/build/cargo-tarball-b8d713fa01725c21/out/completions"
+    path: "{{cargo.target_directory}}/debug/build/cargo-tarball-63c1f7d9f2ae9bcc/out/completions"
     pattern: "*"


### PR DESCRIPTION
Target can be set on the command line.  It defaults to what
`cargo-tarball` was built.

The default is not set in `args.rs` because of the circular nature of
generating it and reading args to create completions.